### PR TITLE
fix prepare double endline templating

### DIFF
--- a/catcher_modules/__init__.py
+++ b/catcher_modules/__init__.py
@@ -1,3 +1,3 @@
 APPNAME = 'catcher-modules'
 APPAUTHOR = 'Valerii Tikhonov'
-APPVSN = '3.6.1'
+APPVSN = '3.6.2'

--- a/catcher_modules/database/__init__.py
+++ b/catcher_modules/database/__init__.py
@@ -227,7 +227,7 @@ class SqlAlchemyDb:
     @classmethod
     def __read_n_fill_csv(cls, csv_path, variables):
         with open(csv_path) as csv_file:
-            csv_content = fill_template_str(csv_file.read(), variables)
+            csv_content = fill_template_str(csv_file.read(), variables).replace('\n\n', '\n')
         return StringIO(csv_content)
 
     @staticmethod


### PR DESCRIPTION
fix \n\n in templates:
```
user_id,email
{% for user in users %}
{{ loop.index }},{{ user }}
{% endfor %}
```