### PR TITLE
use unpause in database for old airflow

### DIFF
--- a/catcher_modules/__init__.py
+++ b/catcher_modules/__init__.py
@@ -1,3 +1,3 @@
 APPNAME = 'catcher-modules'
 APPAUTHOR = 'Valerii Tikhonov'
-APPVSN = '5.2.1'
+APPVSN = '5.2.2'

--- a/catcher_modules/exceptions/airflow_exceptions.py
+++ b/catcher_modules/exceptions/airflow_exceptions.py
@@ -1,0 +1,6 @@
+class OldAirflowVersionException(Exception):
+    """
+    Old versions of airflow doesn't have rest api (or partly have it).
+    In case such exception it would be better to do the same via Airflow db (if possible)
+    """
+    pass

--- a/catcher_modules/pipeline/airflow_utils/airflow_client.py
+++ b/catcher_modules/pipeline/airflow_utils/airflow_client.py
@@ -1,6 +1,7 @@
 import posixpath
 
 from catcher.utils.logger import debug
+from catcher_modules.exceptions.airflow_exceptions import OldAirflowVersionException
 from requests import request
 
 
@@ -22,6 +23,9 @@ def trigger_dag(aiflow_url, dag_id, dag_config):
 def unpause_dag(aiflow_url, dag_id):
     url = posixpath.join(aiflow_url, 'api/experimental/dags/{}/paused/false'.format(dag_id))
     r = request('GET', url)
+    if r.status_code == 404:  # old airflow, rest api is not suported
+        debug('Endpoint not found: ' + r.text)
+        raise OldAirflowVersionException('Can\'t unpause the dag {}'.format(dag_id))
     if r.status_code != 200:
         debug(r.text)
         raise Exception('Can\'t unpause dag: {}'.format(dag_id))

--- a/catcher_modules/pipeline/airflow_utils/airflow_db_client.py
+++ b/catcher_modules/pipeline/airflow_utils/airflow_db_client.py
@@ -52,6 +52,19 @@ def check_dag_exists(dag_id, conf, dialect) -> bool:
         return found != []
 
 
+def unpause_dag(dag_id, conf, dialect) -> bool:
+    """
+    Unpause dag directly in the database. 
+    Please use airflow_client.unpause_dag (if your version of airflow supports it instead.
+    """
+    engine = db_utils.get_engine(conf, dialect)
+    with engine.connect() as connection:
+        result = connection.execute('''update dag set is_paused=false 
+                                       where dag_id = '{}'
+                                            '''.format(dag_id))
+        return result.rowcount == 1
+
+
 def check_import_errors(dag_id, conf, dialect):
     """
     Check if there was import error for the dag


### PR DESCRIPTION
old versions of airflow doesn't have some (or all) rest endpoints.
fixed unpause dag case
closes https://github.com/comtihon/catcher_modules/issues/59