### PR TITLE
BugFixes: airflow module old airflow vs new airflow (part 2)

### DIFF
--- a/catcher_modules/__init__.py
+++ b/catcher_modules/__init__.py
@@ -1,3 +1,3 @@
 APPNAME = 'catcher-modules'
 APPAUTHOR = 'Valerii Tikhonov, Ekaterina Belova'
-APPVSN = '5.2.3'
+APPVSN = '5.2.4'

--- a/catcher_modules/pipeline/airflow.py
+++ b/catcher_modules/pipeline/airflow.py
@@ -222,7 +222,9 @@ class Airflow(ExternalStep):
                 state = airflow_client.get_run_status(url, dag_id, execution_date)
             except OldAirflowVersionException:
                 warning("Your airflow version does not support rest API method for DAG status. Call backend db directly")
-                state = airflow_db_client.get_dag_run_by_run_ud(run_id=run_id, conf=db_conf, dialect=dialect)["state"]
+                state = airflow_db_client.get_dag_run_by_run_ud(run_id=run_id,
+                                                                conf=db_conf,
+                                                                dialect=dialect)["state"]
 
             debug(state)
             if state.lower() != 'running':

--- a/catcher_modules/pipeline/airflow_utils/airflow_client.py
+++ b/catcher_modules/pipeline/airflow_utils/airflow_client.py
@@ -3,12 +3,13 @@ import posixpath
 from catcher.utils.logger import debug
 from catcher_modules.exceptions.airflow_exceptions import OldAirflowVersionException
 from requests import request
+import datetime
 
 
 def trigger_dag(aiflow_url, dag_id, dag_config):
     url = posixpath.join(aiflow_url, 'api/experimental/dags/{}/dag_runs'.format(dag_id))
     r = request('POST', url, json=dag_config, headers={'content-type': 'application/json'})
-    if r.status_code == 404:  # old airflow, rest api is not supported
+    if r.status_code in [404, 405]:  # old airflow, rest api is not supported
         debug('Endpoint not found: ' + r.text)
         raise OldAirflowVersionException('Can\'t trigger dag {}'.format(dag_id))
 
@@ -27,7 +28,7 @@ def trigger_dag(aiflow_url, dag_id, dag_config):
 def unpause_dag(aiflow_url, dag_id):
     url = posixpath.join(aiflow_url, 'api/experimental/dags/{}/paused/false'.format(dag_id))
     r = request('GET', url)
-    if r.status_code == 404:  # old airflow, rest api is not supported
+    if r.status_code in [404, 405]:  # old airflow, rest api is not supported
         debug('Endpoint not found: ' + r.text)
         raise OldAirflowVersionException('Can\'t unpause the dag {}'.format(dag_id))
     if r.status_code != 200:
@@ -38,7 +39,7 @@ def unpause_dag(aiflow_url, dag_id):
 def get_dag_run(aiflow_url: str, dag_id: str, run_id: str) -> dict:
     url = posixpath.join(aiflow_url, 'api/experimental/dags/{}/dag_runs'.format(dag_id))
     r = request('GET', url)
-    if r.status_code == 404:  # old airflow, rest api is not supported
+    if r.status_code in [404, 405]:  # old airflow, rest api is not supported
         debug('Endpoint not found: ' + r.text)
         raise OldAirflowVersionException('Can\'t get dag run {}'.format(dag_id))
     if r.status_code != 200:
@@ -47,19 +48,26 @@ def get_dag_run(aiflow_url: str, dag_id: str, run_id: str) -> dict:
     dag_run = filter(lambda x: x['run_id'] == run_id, r.json())
     if not dag_run:
         raise Exception('No run_id {} found in runs for dag {}'.format(run_id, dag_id))
-    # TODO potential issue: will always return the same run_id the last one or the first one ???
     return list(dag_run)[0]
 
 
 def get_run_status(aiflow_url: str, dag_id: str, execution_date: str) -> str:
-    # TODO Potential issue dag can have multiplied runs, unclear, which one will be returned here
-    #  or dag_id == run_id ?
-    url = posixpath.join(aiflow_url, 'api/experimental/dags/{}/dag_runs/{}'.format(dag_id, execution_date))
+    """
+    Obtain pipeline status depends on dag_id and execution_date
+    :param aiflow_url:
+    :param dag_id: unique id for DAG. Name of the pipeline.
+    :param execution_date: it is datetime object already, not string.
+    :return: dag state (success, running, failed)
+    """
+    date_format = "%Y-%m-%dT%H:%M:%S"
+    date_fmt = execution_date.strftime(date_format)
+
+    url = posixpath.join(aiflow_url, 'api/experimental/dags/{}/dag_runs/{}'.format(dag_id, date_fmt))
     r = request('GET', url)
-    if r.status_code == 404:  # old airflow, rest api is not supported
+    if r.status_code in [404, 405]:  # old airflow, rest api is not supported
         debug('Endpoint not found: ' + r.text)
         raise OldAirflowVersionException('Can\'t get dag run status {}'.format(dag_id))
 
     if r.status_code != 200:
-        raise Exception('Can\'t get run status for {}:{}  {}'.format(dag_id, execution_date, r.json()))
+        raise Exception('Can\'t get run status for {}:{}  {}'.format(dag_id, date_fmt, r.json()))
     return r.json()['state']


### PR DESCRIPTION
Continue debug of airflow module, found and fixed two issues more: 
* in some cases old versions of Airflow returns 405 error response - add it into list;
* fix execution_date format provided into [restAPI method](https://airflow.apache.org/docs/stable/rest-api-ref.html#get--api-experimental-dags--string-dag_id--dag_runs--string-execution_date-)