### PR TITLE
added delete for docker stop

### DIFF
--- a/catcher_modules/__init__.py
+++ b/catcher_modules/__init__.py
@@ -1,3 +1,3 @@
 APPNAME = 'catcher-modules'
 APPAUTHOR = 'Valerii Tikhonov, Ekaterina Belova'
-APPVSN = '5.2.4'
+APPVSN = '5.3.1'

--- a/catcher_modules/service/docker.py
+++ b/catcher_modules/service/docker.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod, ABCMeta
 from catcher.steps.external_step import ExternalStep
 from catcher.steps.step import update_variables
+from catcher.utils.logger import debug
 
 
 class DockerCmd(metaclass=ABCMeta):
@@ -40,8 +41,17 @@ class IdBasedCmd:
 
 
 class StopCmd(IdBasedCmd, DockerCmd):
+    def __init__(self, delete=False, **kwargs: dict) -> None:
+        IdBasedCmd.__init__(self, **kwargs)
+        self.delete = delete
+
     def action(self, variables):
-        return self.get_container().stop()
+        container = self.get_container()
+        res = container.stop()
+        if self.delete:
+            debug('Removing {}'.format(container.name))
+            container.remove()
+        return res
 
 
 class StatusCmd(IdBasedCmd, DockerCmd):
@@ -173,6 +183,7 @@ class Docker(ExternalStep):
 
     - name: container's name. *Optional*
     - hash: container's hash. *Optional* Either name or hash should present
+    - delete: delete a container. *Optional* (default is false)
 
     :status: get the container status.
 

--- a/test/docker_test.py
+++ b/test/docker_test.py
@@ -1,6 +1,9 @@
 import os
 from os.path import join
 
+import docker
+import pytest
+
 from test.abs_test_class import TestClass
 
 from catcher.core.runner import Runner
@@ -83,6 +86,26 @@ class DockerTest(TestClass):
                             ''')
         runner = Runner(self.test_dir, join(self.test_dir, 'main.yaml'), None)
         self.assertTrue(runner.run_tests())
+
+    def test_stop_and_remove(self):
+        self.populate_file('main.yaml', '''---
+                                    steps:
+                                        - docker: 
+                                            start: 
+                                                image: 'jamesdbloom/mockserver'
+                                                ports:
+                                                    '1080/tcp': 8001
+                                                name: mockserver
+                                        - docker:
+                                            stop:
+                                                name: mockserver
+                                                delete: true            
+                                    ''')
+        runner = Runner(self.test_dir, join(self.test_dir, 'main.yaml'), None)
+        self.assertTrue(runner.run_tests())
+        client = docker.from_env()
+        with pytest.raises(docker.errors.NotFound):
+            client.containers.get('mockserver')
 
     def test_get_logs(self):
         self.populate_file('main.yaml', '''---


### PR DESCRIPTION
closes https://github.com/comtihon/catcher_modules/issues/56
Added delete option for docker stop:
```
docker:
        stop:
            name: mockserver
            delete: true    
```