### PR TITLE
Fix airflow parse run_id in `trigger_dag`.

### DIFF
--- a/catcher_modules/__init__.py
+++ b/catcher_modules/__init__.py
@@ -1,3 +1,3 @@
 APPNAME = 'catcher-modules'
 APPAUTHOR = 'Valerii Tikhonov, Ekaterina Belova'
-APPVSN = '5.4.3'
+APPVSN = '5.4.4'


### PR DESCRIPTION
When the dag is triggered manually with an execution date config execution date dag config, the message returned when the dag is triggered using the REST API 'api/experimental/dags/{}/dag_runs' in the `trigger_dag` method has a slightly different message.

**When dag is triggered without execution date**
'Created <DagRun hello_world @ 2020-01-04 13:22:16+00:00: manual__2020-01-04T13:22:16+00:00`

**When dag is triggered with specified execution date**
'Created <DagRun hello_world @ 2019-08-25`T`14:15:22+00:00: manual__2019-08-25T14:15:22+00:00, externally triggered: True>'

Since in the existing code, the message is parsed by using whitespace as a delimiter to obtain the dag run id of `manual__....`, the code is breaking due to the whitespace being replaced by `T` when triggered using a specified execution date. https://github.com/comtihon/catcher_modules/pull/72/files#diff-4f0f68c59fe85d07a386e98dc788acf56746010dde383df851392ed1d587bb13L26

Please let could you let me know if this fix is acceptable? 


Existing error message

```
DEBUG:catcher:Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/catcher/core/runner.py", line 81, in _run_test
    test.run()
  File "/usr/local/lib/python3.7/site-packages/catcher/core/test.py", line 71, in run
    if not self._run_step(step, tag, raise_stop):
  File "/usr/local/lib/python3.7/site-packages/catcher/core/test.py", line 95, in _run_step
    if not self._run_actions(step, action, action_object, self.variables, raise_stop, ignore_errors):
  File "/usr/local/lib/python3.7/site-packages/catcher/core/test.py", line 132, in _run_actions
    raise e
  File "/usr/local/lib/python3.7/site-packages/catcher/core/test.py", line 105, in _run_actions
    self.variables = action_object.action(self.includes, variables)
  File "/usr/local/lib/python3.7/site-packages/catcher/steps/step.py", line 235, in wrapper
    result = func(self, *args, **kwargs)
  File "/catcher_modules/catcher_modules/pipeline/airflow.py", line 136, in action
    return variables, self._run_dag(oper, variables.get('INVENTORY_FILE'))
  File "/catcher_modules/catcher_modules/pipeline/airflow.py", line 159, in _run_dag
    execution_date = airflow_client.get_dag_run(url, dag_id, run_id)['execution_date']
  File "/catcher_modules/catcher_modules/pipeline/airflow_utils/airflow_client.py", line 52, in get_dag_run
    return list(dag_run)[0]
IndexError: list index out of range

```




